### PR TITLE
Fix astro check errors

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,7 +1,7 @@
 ---
-import EditLink from 'virtual:starlight/components/EditLink';
-import LastUpdated from 'virtual:starlight/components/LastUpdated';
-import Pagination from 'virtual:starlight/components/Pagination';
+import EditLink from '@astrojs/starlight/components/EditLink.astro';
+import LastUpdated from '@astrojs/starlight/components/LastUpdated.astro';
+import Pagination from '@astrojs/starlight/components/Pagination.astro';
 import config from 'virtual:starlight/user-config';
 import { Icon } from '@astrojs/starlight/components';
 const { authors } = Astro.locals.starlightRoute.entry.data;

--- a/src/components/ScriptResources.astro
+++ b/src/components/ScriptResources.astro
@@ -2,27 +2,24 @@
 import ScriptResourceLinks from "./ScriptResourceLinks.astro";
 
 const { scrpropname, scrpropcode } = Astro.locals.starlightRoute.entry.data;
-const { detailSummary} = Astro.props;
+const { detailSummary } = Astro.props;
 const ssurl = scrpropcode ? `https://scriptsource.org/scr/${scrpropcode}` : "https://scriptsource.org";
 const wikiurl = scrpropname ? `https://wikipedia.org/wiki/${scrpropname}` : "https://en.wikipedia.org/wiki/Script_(Unicode)";
 const label4script = scrpropname ? ` for ${scrpropname}` : '';
+const seemore = detailSummary === "seemore";
 ---
 
 <ul>
 	<li><a href={ssurl} target="_blank">ScriptSource page{label4script}</a> - all about scripts, languages, and writing systems</li>
-
-{detailSummary === "seemore" ? (
-	</ul>
+	{ !seemore && <ScriptResourceLinks label4script={label4script} wikiurl={wikiurl} /> }
+</ul>
+{ seemore && (
 	<details>
 		<summary>See more...</summary>
 		<ul>
 			<ScriptResourceLinks label4script={label4script} wikiurl={wikiurl} />
 		</ul>
 	</details>
-
-) : (
-		<ScriptResourceLinks label4script={label4script} wikiurl={wikiurl} />
-	</ul>
 )}
 
 <style>

--- a/src/components/WsVarList.astro
+++ b/src/components/WsVarList.astro
@@ -9,7 +9,7 @@ const varCount = wsObj ? wsObj.Variants.length : 10000;
 ---
 
 				<td>
-				{wsObj.Variants.map((varObj) => (
+				{wsObj && (wsObj.Variants.map((varObj) => (
 					<span>{varObj.Code} 
 					{
 						(varObj.Country && varObj.Country !== 'none') ? (
@@ -17,7 +17,7 @@ const varCount = wsObj ? wsObj.Variants.length : 10000;
 						) : ''
 					}
 					</span><br/>
-				))}</td>
+				)))}</td>
 
 <style>
 </style>


### PR DESCRIPTION
* Fix import errors in `src/component/Footer.astro` that probably should have been caught during the upgrade to astro5.
* Fix a subtle mis-render in `src/components/ScriptResource.astro`, when the closing `</ul>` gets stripped during page generation. (this used to work until a bug fix to astro went in).
* Stop `astro check` wingeing about wsObj possibling being null.  this currently is impossible, at the current call site. But is could be possible were it not called from an ` map()` over the script_ws.json array.