### PR TITLE
Add a cookie consent banner

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,78 @@ import starlightLinksValidator from 'starlight-links-validator';
 import astroBrokenLinksChecker from 'astro-broken-links-checker';
 import rehypeFigureTitle from 'rehype-figure-title';
 import rehypeExternalLinks from 'rehype-external-links';
+import cookieconsent from "@jop-software/astro-cookieconsent";
+
+const cookieconfig = {
+    guiOptions: {
+        consentModal: {
+            layout: 'box inline',
+            position: 'bottom left',
+        },
+    },
+    categories: {
+        analytics: {
+            enabled: true,
+            services: {
+                ga4: {
+                    label:
+                        '<a href="https://marketingplatform.google.com/about/analytics/terms/us/" target="_blank">Google Analytics 4</a>',
+                    cookies: [
+                        {
+                            name: /^(_ga|gid)/,
+                        },
+                    ],
+                },
+            },
+        },
+    },
+    language: {
+        default: 'en',
+        autoDetect: 'browser',
+        translations: {
+            en: {
+                consentModal: {
+                    title: 'We use analytics cookies',
+                    description:
+                        'Our website uses Google Analytics cookies to understand how you interact with it.\
+                         These will only be enabled if you accept explicitly.',
+                    acceptAllBtn: 'Accept all',
+                    acceptNecessaryBtn: 'Reject all',
+                    showPreferencesBtn: 'Manage preferences',
+                    footer: '<a href="/support/policies/#privacy">Privacy Policy</a>',
+                },
+                preferencesModal: {
+                    title: 'Consent Preferences Center',
+                    acceptAllBtn: 'Accept all',
+                    acceptNecessaryBtn: 'Reject all',
+                    savePreferencesBtn: 'Save preferences',
+                    closeIconLabel: 'Close modal',
+                    serviceCounterLabel: 'Service|Services',
+                    sections: [
+                        {
+                            title: 'Cookie Usage',
+                            description:
+                                'We use cookies strictly for analytics on this site and never for advertising',
+                        },
+                        {
+                            title: 'Analytics',
+                            description:
+                                'We use Google Analytics, configured to never collect, or share user identity information.',
+                            linkedCategory: 'analytics',
+                        },
+                        {
+                            title: 'More information',
+                            description:
+                                'For any query in relation to our policy on\
+                                 cookies and your choices, please\
+                                 <a class="cc__link" href="/support/contact/">contact me</a>.',
+                        },
+                    ],
+                },
+            },
+        },
+    },
+};
 
 const googleAnalyticsId = 'G-WHT6CVPT8M'
 
@@ -28,24 +100,36 @@ export default defineConfig({
                     attrs: { 
                         defer: true 
                     },
-                    content: `
+                    content:`
                         window.dataLayer = window.dataLayer || [];
                         function gtag(){dataLayer.push(arguments);}
                         gtag('js', new Date());
-                        gtag('config', '${googleAnalyticsId}', { debug_mode: true });`
+                        gtag('config', '${googleAnalyticsId}');
+                    `
                 },
                 {
                     tag: 'script',
-                    attrs: { 
-                        defer: true 
+                    attrs: {
+                        defer: true,
+                        type: 'text/plain',
+                        'data-category': 'analytics'
                     },
-                    content: `
-                        gtag('consent', 'update', {
-                            ad_storage: 'denied', 
-                            ad_user_data: 'denied',
-                            ad_personalization: 'denied',
-                            analytics_storage: 'granted'
-                        });`
+                    content:`
+                        gtag('consent', 'update', { analytics_storage: 'granted'});
+                        console.log('granted analytics consent.');
+                    `
+                },
+                {
+                    tag: 'script',
+                    attrs: {
+                        defer: true,
+                        type: 'text/plain',
+                        'data-category': '!analytics'
+                    },
+                    content:`
+                        gtag('consent', 'update', { analytics_storage: 'denied'});
+                        console.log('denied analytics consent.');
+                    `
                 }
             ],
             markdown: {
@@ -120,6 +204,7 @@ export default defineConfig({
           logFilePath: 'broken-links.log',  // Optional: specify the log file path
           checkExternalLinks: false         // Optional: check external links (currently, caching to disk is not supported, and it is slow )
         }),
+        cookieconsent(cookieconfig),
     ],
     markdown: {
         rehypePlugins: [rehypeFigureTitle,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@astrojs/check": "^0.9.4",
         "@astrojs/starlight": "^0.34.4",
+        "@jop-software/astro-cookieconsent": "^3.0.1",
         "astro": "^5.11.0",
         "astro-broken-links-checker": "imazen/astro-broken-link-checker",
         "rehype-external-links": "^3.0.0",
@@ -17,7 +18,8 @@
         "sharp": "^0",
         "starlight-links-validator": "^0.17.0",
         "typescript": "^5",
-        "unist-util-visit": "^5.0.0"
+        "unist-util-visit": "^5.0.0",
+        "vanilla-cookieconsent": "^3.1.0"
       }
     },
     "node_modules/@astrojs/check": {
@@ -1252,6 +1254,15 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jop-software/astro-cookieconsent": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@jop-software/astro-cookieconsent/-/astro-cookieconsent-3.0.1.tgz",
+      "integrity": "sha512-UXo6aMR9/kEEmUIZoRTRJXDf/ADju9qQ0qNRWM1twdf0vRCh2s/ucHqaYOcs57Q2PcKmcq+Sc+0Tq0gSUgVDzA==",
+      "license": "GPL-3.0-or-later",
+      "peerDependencies": {
+        "vanilla-cookieconsent": "^3.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -7409,6 +7420,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/vanilla-cookieconsent": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vanilla-cookieconsent/-/vanilla-cookieconsent-3.1.0.tgz",
+      "integrity": "sha512-/McNRtm/3IXzb9dhqMIcbquoU45SzbN2VB+To4jxEPqMmp7uVniP6BhGLjU8MC7ZCDsNQVOp27fhQTM/ruIXAA==",
       "license": "MIT"
     },
     "node_modules/vfile": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@astrojs/check": "^0.9.4",
     "@astrojs/starlight": "^0.34.4",
+    "@jop-software/astro-cookieconsent": "^3.0.1",
     "astro": "^5.11.0",
     "astro-broken-links-checker": "imazen/astro-broken-link-checker",
     "rehype-external-links": "^3.0.0",
@@ -20,6 +21,7 @@
     "sharp": "^0",
     "starlight-links-validator": "^0.17.0",
     "typescript": "^5",
-    "unist-util-visit": "^5.0.0"
+    "unist-util-visit": "^5.0.0",
+    "vanilla-cookieconsent": "^3.1.0"
   }
 }

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -16,7 +16,9 @@ const { authors } = Astro.locals.starlightRoute.entry.data;
 		<p class="authors">Authors: {authors}</p>
 		)
 	}
-        <p>Copyright © 2001-2025 SIL Global and released under the Creative Commons Attribution-ShareAlike 4.0 International license <a href="https://creativecommons.org/licenses/by-sa/4.0/">(CC BY-SA 4.0)</a> unless noted otherwise. <a href="https://writingsystems.info/support/policies/">Terms of Service, Terms of Use, and Privacy Policy.</a></p>
+        <p>Copyright © 2001-2025 SIL Global and released under the Creative Commons Attribution-ShareAlike 4.0 International license <a href="https://creativecommons.org/licenses/by-sa/4.0/">(CC BY-SA 4.0)</a> unless noted otherwise. <a href="https://writingsystems.info/support/policies/">Terms of Service, Terms of Use, and Privacy Policy.</a>
+		   <a href="" data-cc="show-preferencesModal" class="cc__link">Manage cookie consent preferences</a>
+		</p>
 	</div>
 	<Pagination />
 

--- a/src/content/docs/support/policies.md
+++ b/src/content/docs/support/policies.md
@@ -28,7 +28,7 @@ For information on authorship and details of content used by permission see [Ack
 
 ## Privacy
 
-We do not collect, or transmit, any personally identifiable information for any purposes. We do use Google Analytics and store cookies for analytics purposes only, but we do not run advertising on this site, or store any 3rd party cookies for advertising purposes. This site does store a small ammount of local data for maintaining the state of the side bar between visits, which never leaves you browser. We use Google Analytics to anonymously log page metrics, with all consent options except analytics storage set to denied by default.
+We do not collect, or transmit, any personally identifiable information for any purposes. We do use Google Analytics, and store cookies for analytics purposes only, but we do not run advertising on this site, or store any 3rd party cookies for advertising purposes. This site does store a small ammount of local data for maintaining the state of the side bar between visits, which never leaves you browser. We use Google Analytics to anonymously log page metrics, with all consent options except analytics storage set to denied by default. You can change your <a href="" data-cc="show-preferencesModal" class="cc__link">consent preferences</a> at any time.
 This site is currently under development, and this policy may change at any time.
 
 ## Feedback


### PR DESCRIPTION
Add a cookie consent banner and integrate it with the site.
Update the Pivacy policy, and add links to modify any previously set consent options.

Consenting to `analytics_storage` enables GA4 to begin collecting useful data.